### PR TITLE
修复windows环境下报错：java.sql.SQLException: path to '//rules.db': '\\' does not exist

### DIFF
--- a/src/main/java/org/fofaviewer/utils/SQLiteUtils.java
+++ b/src/main/java/org/fofaviewer/utils/SQLiteUtils.java
@@ -29,7 +29,7 @@ public class SQLiteUtils {
     public static String getPath() {
         try{
             String jarPath = java.net.URLDecoder.decode(DataUtil.class.getProtectionDomain().getCodeSource().getLocation().getFile(), String.valueOf(StandardCharsets.UTF_8));
-            return jarPath.substring(0, jarPath.lastIndexOf(System.getProperty("file.separator")) + 1);
+            return jarPath.substring(0, jarPath.lastIndexOf("/") + 1);
         }catch (Exception e){
             Logger.error(e);
         }


### PR DESCRIPTION
因windows环境下路径分隔符不同产生报错
![image](https://github.com/wgpsec/fofa_viewer/assets/14084820/df46676f-607e-4fb0-ae39-19712d38d1ac)
